### PR TITLE
Fix draw order issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ set(SOURCE_FILES
         src/InputHandler.cpp
         src/Player.cpp
         src/Scene.cpp
-        src/SceneHandler.cpp)
+        src/SceneHandler.cpp
+        src/GameObjectCollection.cpp)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
 

--- a/src/GameObject.hpp
+++ b/src/GameObject.hpp
@@ -7,18 +7,14 @@
 #include <SFML/Graphics/Drawable.hpp>
 
 class Game;
-
-class GameObject;
-
-using GameObjectCollection = std::unordered_map<std::string, std::shared_ptr<GameObject>>;
+class GameObjectCollection;
 
 class GameObject : public sf::Drawable {
 public:
-    virtual void update(Game&, const GameObjectCollection&, float deltaTime) noexcept = 0;
+    virtual void update(Game&, GameObjectCollection&, float deltaTime) noexcept = 0;
 
 private:
     virtual void draw(sf::RenderTarget&, sf::RenderStates) const = 0;
 };
-
 
 #endif // GAMEOBJECT_H

--- a/src/GameObjectCollection.cpp
+++ b/src/GameObjectCollection.cpp
@@ -1,0 +1,48 @@
+#include "GameObjectCollection.hpp"
+
+std::weak_ptr<GameObject> GameObjectCollection::getObject(const std::string& name) const noexcept {
+    if (m_gameObjectMap.find(name) != m_gameObjectMap.end()) {
+        return m_gameObjectMap.at(name);
+    }
+
+    return std::weak_ptr<GameObject>();
+}
+
+void GameObjectCollection::addObject(const std::string& name, std::shared_ptr<GameObject> object, int zIndex) {
+    m_gameObjectMap.emplace(name, object);
+    m_gameObjectDrawOrder[zIndex].push_back(object);
+}
+
+GameObjectCollection::iterator GameObjectCollection::begin() const {
+    auto drawOrderIt = m_gameObjectDrawOrder.begin();
+    return iterator(drawOrderIt, m_gameObjectDrawOrder.end(), drawOrderIt->second.begin());
+}
+
+GameObjectCollection::iterator GameObjectCollection::end() const {
+    auto drawOrderIt = m_gameObjectDrawOrder.end();
+    return iterator(drawOrderIt, m_gameObjectDrawOrder.end(), drawOrderIt->second.end());
+}
+
+GameObjectCollection::iterator::iterator(
+    GameObjectDrawOrder::const_iterator drawOrderIt,
+    GameObjectDrawOrder::const_iterator drawOrderEnd,
+    GameObjectList::const_iterator objectIt)
+    : m_drawOrderIt(drawOrderIt), m_drawOrderEnd(drawOrderEnd), m_objectIt(objectIt) {
+}
+
+GameObjectCollection::iterator GameObjectCollection::iterator::operator++() {
+    if (++m_objectIt == m_drawOrderIt->second.end()) {
+        if (++m_drawOrderIt == m_drawOrderEnd) {
+            m_objectIt = m_drawOrderIt->second.end();
+        }
+    }
+    return *this;
+}
+
+bool GameObjectCollection::iterator::operator != (const GameObjectCollection::iterator& other) const {
+    return m_drawOrderIt != other.m_drawOrderIt || m_objectIt != other.m_objectIt;
+}
+
+const std::shared_ptr<GameObject>& GameObjectCollection::iterator::operator*() const {
+    return *m_objectIt;
+}

--- a/src/GameObjectCollection.hpp
+++ b/src/GameObjectCollection.hpp
@@ -1,0 +1,50 @@
+#ifndef GAMEOBJECTCOLLECTION_H
+#define GAMEOBJECTCOLLECTION_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class GameObject;
+
+using GameObjectMap = std::unordered_map<std::string, std::shared_ptr<GameObject>>;
+using GameObjectList = std::vector<std::shared_ptr<GameObject>>;
+using GameObjectDrawOrder = std::map<int, GameObjectList>;
+
+class GameObjectCollection {
+public:
+    class iterator {
+    public:
+        iterator(
+            GameObjectDrawOrder::const_iterator drawOrderIt,
+            GameObjectDrawOrder::const_iterator drawOrderEnd,
+            GameObjectList::const_iterator objectIt);
+
+        iterator operator++();
+
+        bool operator != (const iterator& other) const;
+
+        const std::shared_ptr<GameObject>& operator* () const;
+
+    private:
+        GameObjectDrawOrder::const_iterator m_drawOrderIt;
+        GameObjectDrawOrder::const_iterator m_drawOrderEnd;
+        GameObjectList::const_iterator m_objectIt;
+    };
+
+    void addObject(const std::string& name, std::shared_ptr<GameObject>, int zIndex = 0);
+
+    std::weak_ptr<GameObject> getObject(const std::string& name) const noexcept;
+
+    iterator begin() const;
+    iterator end() const;
+
+private:
+    GameObjectMap m_gameObjectMap;
+    GameObjectDrawOrder m_gameObjectDrawOrder;
+};
+
+
+#endif // GAMEOBJECTCOLLECTION_H

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -12,5 +12,5 @@ void GameScene::initialize(Game& game) {
 
     auto player = std::make_shared<Player>();
     player->load(game);
-    addObject("player", player);
+    m_gameObjects.addObject("player", player);
 }

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -22,7 +22,7 @@ void Player::load(Game& game) {
     m_sprite.play("idle");
 }
 
-void Player::update(Game& game, const GameObjectCollection&, float deltaTime) noexcept {
+void Player::update(Game& game, GameObjectCollection&, float deltaTime) noexcept {
     auto& input = game.getInputHandler();
 
     const bool movingLeft = input.getKeyDown(sf::Keyboard::Left);

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -12,7 +12,7 @@ public:
 
     void load(Game&);
 
-    void update(Game&, const GameObjectCollection&, float deltaTime) noexcept override;
+    void update(Game&, GameObjectCollection&, float deltaTime) noexcept override;
 
 private:
     const float m_speed = 200.f;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,26 +1,14 @@
+#include "GameObject.hpp"
 #include "Scene.hpp"
 
 void Scene::update(Game& game, float deltaTime) noexcept {
-    for (auto& object : m_objects) {
-        object.second->update(game, m_objects, deltaTime);
+    for (auto& object : m_gameObjects) {
+        object->update(game, m_gameObjects, deltaTime);
     }
 }
 
 void Scene::draw(sf::RenderWindow& window) noexcept {
-    for (auto& object : m_objectsDrawOrder) {
-        window.draw(*object.second);
+    for (auto& object : m_gameObjects) {
+        window.draw(*object);
     }
-}
-
-std::weak_ptr<GameObject> Scene::getObject(const std::string& name) noexcept {
-    if (m_objects.find(name) != m_objects.end()) {
-        return m_objects[name];
-    }
-
-    return std::weak_ptr<GameObject>();
-}
-
-void Scene::addObject(const std::string& name, std::shared_ptr<GameObject> object, int zIndex) {
-    m_objects.emplace(name, object);
-    m_objectsDrawOrder.emplace(zIndex, object);
 }

--- a/src/Scene.hpp
+++ b/src/Scene.hpp
@@ -3,7 +3,7 @@
 
 #include <SFML/Graphics.hpp>
 
-#include "GameObject.hpp"
+#include "GameObjectCollection.hpp"
 
 class Game;
 
@@ -15,15 +15,8 @@ public:
 
     void draw(sf::RenderWindow&) noexcept;
 
-    std::weak_ptr<GameObject> getObject(const std::string& name) noexcept;
-
 protected:
-    GameObjectCollection m_objects;
-
-    void addObject(const std::string& name, std::shared_ptr<GameObject>, int zIndex = 0);
-
-private:
-    std::map<int, std::shared_ptr<GameObject>> m_objectsDrawOrder;
+    GameObjectCollection m_gameObjects;
 };
 
 #endif // SCENE_H


### PR DESCRIPTION
Only one game object per z-index would be allowed, now a dedicated game
object collection class handles proper iteration order and multiple game
objects per z-index.